### PR TITLE
Fix a WSOD

### DIFF
--- a/wpseo-pinterest-rich-pins-woocommerce.php
+++ b/wpseo-pinterest-rich-pins-woocommerce.php
@@ -69,7 +69,9 @@ class WPSEO_Pinterest_Rich_Pins {
 	 * @since 0.1
 	 */
 	function set_meta_box() {
-		$this->meta_box = new WPSEO_Metabox();
+		if ( class_exists( 'WPSEO_Metabox' ) ) {
+			$this->meta_box = new WPSEO_Metabox();
+		}
 	}
 
 	/**


### PR DESCRIPTION
If Yoast SEO plugin not installed or inactive, we get a WSOD with this error: "Fatal error: Class undefined: WPSEO_Metabox in..."
