### PR TITLE
Updated instock level to match OG style

### DIFF
--- a/wpseo-pinterest-rich-pins-woocommerce.php
+++ b/wpseo-pinterest-rich-pins-woocommerce.php
@@ -299,7 +299,7 @@ class WPSEO_Pinterest_Rich_Pins {
 
 		switch ( $stock_level ) {
 			case 'instock':
-				$stock_level = 'in stock';
+				$stock_level = 'instock';
 				break;
 			case 'outofstock';
 				$stock_level = $product->backorders_allowed() ? 'backorder' : 'out of stock';


### PR DESCRIPTION
The stock level of "in stock" needs to be written as "instock" for Open Graph.

https://developers.facebook.com/docs/reference/opengraph/object-type/product/

Search for product:availability